### PR TITLE
Refactor scriptlike functions into something more library-like

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 authors = ["Zachary Pierce <zpierce@polysync.io>"]
 
 [dependencies]
-toml = "0.4"
 cmake = "0.1"
+failure = "0.1"
+multimap = "0.4"
+toml = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,130 +1,342 @@
 extern crate cmake;
+#[macro_use]
+extern crate failure;
+extern crate multimap;
 extern crate toml;
 use cmake::Config as CmakeConfig;
+use std::borrow::Borrow;
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum ArchHint {
-    X86,
-    ARM,
-    ARMV8,
+mod types;
+// TODO - more selective use of types
+use multimap::MultiMap;
+pub use types::*;
+
+/// All the things that could go wrong when reading fel4 configuration data
+#[derive(Clone, Debug, Fail, PartialEq)]
+pub enum ConfigError {
+    #[fail(display = "Unable to read the fel4 manifest file")]
+    FileReadFailure,
+    #[fail(display = "The fel4 manifest file is unparseable as toml")]
+    TomlParseFailure,
+    #[fail(display = "The fel4 manifest file is missing the {} table", _0)]
+    MissingTable(String),
+    #[fail(display = "The fel4 manifest file contained an unexpected table or array {}", _0)]
+    UnexpectedStructure(String),
+    #[fail(display = "The [{}] table requires the {} property, but it is absent.", _0, _1)]
+    MissingRequiredProperty(String, String),
+    #[fail(display = "The {} property should be specified as a string, but is not", _0)]
+    NonStringProperty(&'static str),
+    #[fail(display = "The {} property should be one of {:?}, but is instead {}", _0, _1, _2)]
+    InvalidValueOption(&'static str, Vec<String>, String),
+    #[fail(
+        display = "The fel4 manifest had a duplicate property {} when resolved to a canonical set",
+        _0
+    )]
+    DuplicateProperty(String),
 }
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct TomlConfig {
-    pub target: String,
-    pub target_arch: ArchHint,
-    pub platform: String,
-    pub cmake_target_config: toml::Value,
-    pub cmake_profile_config: toml::Value,
-    pub cmake_platform_config: toml::Value,
-}
-
-/// Returns a TomlConfig generated from a fel4.toml file.
-pub fn get_toml_config(path: PathBuf, build_profile: &String) -> TomlConfig {
-    let mut manifest_file = File::open(&path)
-        .expect(&format!("failed to open manifest file {}", path.display()));
-
+/// Retrieve the complete contents of the fel4 toml file
+pub fn get_full_manifest<P: AsRef<Path>>(path: P) -> Result<FullFel4Manifest, ConfigError> {
+    let mut manifest_file = match File::open(&path) {
+        Ok(f) => f,
+        Err(_) => return Err(ConfigError::FileReadFailure),
+    };
     let mut contents = String::new();
-
-    manifest_file.read_to_string(&mut contents).unwrap();
-
-    let manifest = contents
-        .parse::<toml::Value>()
-        .expect("failed to parse fel4.toml");
-
-    let fel4_table = match manifest.get("fel4") {
-        Some(t) => t,
-        None => panic!("fel4.toml is missing fel4 table"),
+    match manifest_file.read_to_string(&mut contents) {
+        Ok(_) => {}
+        Err(_) => return Err(ConfigError::FileReadFailure),
     };
-
-    let target = match fel4_table.get("target") {
-        Some(t) => String::from(t.as_str().unwrap()),
-        None => panic!("fel4.toml is missing target key"),
+    let manifest = match contents.parse::<toml::Value>() {
+        Ok(m) => m,
+        Err(_) => return Err(ConfigError::TomlParseFailure),
     };
-
-    let platform = match fel4_table.get("platform") {
-        Some(t) => String::from(t.as_str().unwrap()),
-        None => panic!("fel4.toml is missing platform key"),
-    };
-
-    let target_config = match manifest.get(&target) {
-        Some(t) => t,
-        None => panic!("fel4.toml is missing the target table"),
-    };
-
-    TomlConfig {
-        target: target.clone(),
-        target_arch: if target.contains("arm") {
-            ArchHint::ARM
-        } else if target.contains("aarch64") {
-            ArchHint::ARMV8
-        } else if target.contains("x86") {
-            ArchHint::X86
-        } else {
-            panic!("fel4.toml target is not supported");
-        },
-        platform: platform.clone(),
-        cmake_target_config: target_config.clone(),
-        cmake_profile_config: match target_config.get(&build_profile) {
-            Some(t) => t.clone(),
-            None => panic!("fel4.toml is missing build profile table"),
-        },
-        cmake_platform_config: match target_config.get(&platform) {
-            Some(t) => t.clone(),
-            None => panic!("fel4.toml is missing target platform table"),
-        },
-    }
+    toml_to_full_manifest(manifest)
 }
 
-/// Configure a CMake build configuration from toml.
+/// Parse the complete contents of the fel4 toml
+pub fn toml_to_full_manifest(raw: toml::Value) -> Result<FullFel4Manifest, ConfigError> {
+    let fel4_table = raw.get("fel4")
+        .and_then(toml::Value::as_table)
+        .ok_or_else(|| ConfigError::MissingTable("fel4".into()))?;
+
+    let target: SupportedTarget = fel4_table
+        .get("target")
+        .and_then(toml::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| ConfigError::MissingRequiredProperty("fel4".into(), "target".into()))?
+        .parse()
+        .map_err(|e| {
+            ConfigError::InvalidValueOption("target", SupportedTarget::target_names(), e)
+        })?;
+    let platform: SupportedPlatform = fel4_table
+        .get("platform")
+        .and_then(toml::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| ConfigError::MissingRequiredProperty("fel4".into(), "platform".into()))?
+        .parse()
+        .map_err(|e| {
+            ConfigError::InvalidValueOption("platform", SupportedPlatform::platform_names(), e)
+        })?;
+
+    let artifact_path = fel4_table
+        .get("artifact-path")
+        .and_then(toml::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            ConfigError::MissingRequiredProperty("fel4".into(), "artifact-path".into())
+        })?;
+    let specs_path = fel4_table
+        .get("target-specs-path")
+        .and_then(toml::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            ConfigError::MissingRequiredProperty("fel4".into(), "target-specs-path".into())
+        })?;
+
+    let mut targets: HashMap<SupportedTarget, FullFel4Target> = HashMap::new();
+    for curr_target in SupportedTarget::targets() {
+        let curr_target_name = curr_target.full_name();
+        let curr_target_table = match raw.get(curr_target_name).and_then(toml::Value::as_table) {
+            None => continue,
+            Some(t) => t,
+        };
+        let mut build_profile_properties: MultiMap<BuildProfile, FlatTomlProperty> =
+            MultiMap::new();
+        for profile in BuildProfile::build_profiles() {
+            let profile_name = profile.full_name();
+            let properties = match curr_target_table
+                .get(profile_name)
+                .and_then(toml::Value::as_table)
+            {
+                None => continue,
+                Some(t) => extract_flat_properties(t, false).map_err(|prop_name| {
+                    ConfigError::UnexpectedStructure(format!(
+                        "{}.{}.{}",
+                        curr_target_name, profile_name, prop_name
+                    ))
+                })?,
+            };
+            build_profile_properties
+                .entry(profile)
+                .or_insert_vec(properties);
+        }
+        let mut platform_properties: MultiMap<SupportedPlatform, FlatTomlProperty> =
+            MultiMap::new();
+        for platform in SupportedPlatform::platforms() {
+            let platform_name = platform.full_name();
+            let properties = match curr_target_table
+                .get(platform_name)
+                .and_then(toml::Value::as_table)
+            {
+                None => continue,
+                Some(t) => extract_flat_properties(t, false).map_err(|prop_name| {
+                    ConfigError::UnexpectedStructure(format!(
+                        "{}.{}.{}",
+                        curr_target_name, platform_name, prop_name
+                    ))
+                })?,
+            };
+            platform_properties
+                .entry(platform)
+                .or_insert_vec(properties);
+        }
+        let direct_properties =
+            extract_flat_properties(curr_target_table, true).map_err(|prop_name| {
+                ConfigError::UnexpectedStructure(format!("{}.{}", curr_target_name, prop_name))
+            })?;
+
+        targets.insert(
+            curr_target.clone(),
+            FullFel4Target {
+                identity: curr_target,
+                direct_properties: direct_properties,
+                build_profile_properties: build_profile_properties,
+                platform_properties: platform_properties,
+            },
+        );
+    }
+
+    // TODO - check for superfluous tables
+    // TODO - check for superfluous properties in [fel4]
+
+    Ok(FullFel4Manifest {
+        artifact_path: artifact_path.into(),
+        target_specs_path: specs_path.into(),
+        selected_target: target,
+        selected_platform: platform,
+        targets: targets,
+    })
+}
+
+fn extract_flat_properties(
+    table: &BTreeMap<String, toml::Value>,
+    ignore_structures: bool,
+) -> Result<Vec<FlatTomlProperty>, String> {
+    let mut v = Vec::new();
+    for (prop_name, value) in table {
+        let flat_value = match value {
+            toml::Value::String(v) => FlatTomlValue::String(v.to_string()),
+            toml::Value::Integer(v) => FlatTomlValue::Integer(*v),
+            toml::Value::Float(v) => FlatTomlValue::Float(*v),
+            toml::Value::Boolean(v) => FlatTomlValue::Boolean(*v),
+            toml::Value::Datetime(v) => FlatTomlValue::Datetime(v.clone()),
+            toml::Value::Array(_) | toml::Value::Table(_) => {
+                if ignore_structures {
+                    continue;
+                } else {
+                    return Err(prop_name.to_string());
+                }
+            }
+        };
+        v.push(FlatTomlProperty::new(prop_name.to_string(), flat_value));
+    }
+    Ok(v)
+}
+
+/// Resolve and validate a particular Fel4 configuration for the given `BuildProfile` and the
+/// `selected_target` and `selected_platform` found in the `FullFel4Manifest`
+pub fn resolve_fel4_config<M: Borrow<FullFel4Manifest>>(
+    full: M,
+    build_profile: &BuildProfile,
+) -> Result<Fel4Config, ConfigError> {
+    let selected_target = full.borrow().selected_target.clone();
+    let platform = full.borrow().selected_platform.clone();
+    let target = full.borrow()
+        .targets
+        .get(&selected_target)
+        .ok_or_else(|| ConfigError::MissingTable(selected_target.full_name().to_string()))?;
+
+    let mut properties = HashMap::new();
+    add_properties_to_map(&mut properties, &target.direct_properties)?;
+    let profile_properties = target
+        .build_profile_properties
+        .get_vec(build_profile)
+        .ok_or_else(|| {
+            ConfigError::MissingTable(format!(
+                "{}.{}",
+                selected_target.full_name(),
+                build_profile.full_name()
+            ))
+        })?;
+    add_properties_to_map(&mut properties, profile_properties)?;
+
+    let platform_properties = target
+        .platform_properties
+        .get_vec(&platform)
+        .ok_or_else(|| {
+            ConfigError::MissingTable(format!(
+                "{}.{}",
+                selected_target.full_name(),
+                platform.full_name()
+            ))
+        })?;
+    add_properties_to_map(&mut properties, platform_properties)?;
+
+    Ok(Fel4Config {
+        artifact_path: full.borrow().artifact_path.clone(),
+        target_specs_path: full.borrow().target_specs_path.clone(),
+        target: selected_target,
+        platform: full.borrow().selected_platform.clone(),
+        build_profile: build_profile.clone(),
+        properties: properties,
+    })
+}
+
+fn add_properties_to_map(
+    map: &mut HashMap<String, FlatTomlValue>,
+    source: &Vec<FlatTomlProperty>,
+) -> Result<(), ConfigError> {
+    for p in source {
+        match map.insert(p.name.clone(), p.value.clone()) {
+            None => {}
+            Some(_) => return Err(ConfigError::DuplicateProperty(p.name.clone())),
+        }
+    }
+    Ok(())
+}
+
+/// Things that can go wrong when trying to rely on environment variables
+/// to locate the fel4 manifest and its parameterization.
+#[derive(Clone, Debug, Fail, PartialEq)]
+pub enum ManifestDiscoveryError {
+    #[fail(display = "Required environment variable {} was absent", _0)]
+    MissingEnvVar(String),
+    #[fail(
+        display = "The PROFILE environment variable had a value {} that could not be interpreted as a BuildProfile instance",
+        _0
+    )]
+    InvalidBuildProfile(String),
+}
+
+/// Read environment variables to discover the information necessary to
+/// read and resolve a `Fel4Config`
+pub fn infer_manifest_location_from_env() -> Result<(PathBuf, BuildProfile), ManifestDiscoveryError>
+{
+    let manifest_path = env::var("FEL4_MANIFEST_PATH")
+        .map_err(|_| ManifestDiscoveryError::MissingEnvVar("FEL4_MANIFEST_PATH".to_string()))?;
+    let raw_profile = env::var("PROFILE")
+        .map_err(|_| ManifestDiscoveryError::MissingEnvVar("PROFILE".to_string()))?;
+    let build_profile: BuildProfile = raw_profile
+        .parse()
+        .map_err(|e| ManifestDiscoveryError::InvalidBuildProfile(e))?;
+    Ok((PathBuf::from(manifest_path), build_profile))
+}
+
+/// Load, parse, and resolve a Fel4Config
+pub fn get_fel4_config<P: AsRef<Path>>(
+    fel4_manifest_path: P,
+    build_profile: BuildProfile,
+) -> Result<Fel4Config, ConfigError> {
+    let full_manifest = get_full_manifest(fel4_manifest_path)?;
+    resolve_fel4_config(full_manifest, &build_profile)
+}
+
+#[derive(Clone, Debug, Fail, PartialEq)]
+pub enum CmakeConfigurationError {
+    #[fail(display = "Missing the required {} environment variable", _0)]
+    MissingRequiredEnvVar(String),
+    #[fail(
+        display = "Cargo is attempting to build for the {} target, however fel4.toml has declared the target to be {}",
+        _0,
+        _1
+    )]
+    CargoTargetToFel4TargetMismatch(String, String),
+}
+
+/// Configure a seL4_kernel CMake build configuration with data derived from the fel4.toml manifest
 ///
-/// Returns a TomlConfig representation of fel4.toml.
-pub fn configure_cmake_build(cmake_config: &mut CmakeConfig) -> TomlConfig {
-    let cargo_target = getenv_unwrap("TARGET");
+/// Assumes the presence of the CARGO_MANIFEST_DIR and TARGET environment variables from cargo
+/// Assumes the seL4_kernel is at `${CARGO_MANIFEST_DIR}/deps/seL4_kernel`
+pub fn configure_cmake_build(
+    cmake_config: &mut CmakeConfig,
+    resolved_manifest: &Fel4Config,
+) -> Result<(), CmakeConfigurationError> {
+    let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").map_err(|_| {
+        CmakeConfigurationError::MissingRequiredEnvVar("CARGO_MANIFEST_DIR".to_string())
+    })?;
+    let kernel_path = Path::new(&cargo_manifest_dir)
+        .join("deps")
+        .join("seL4_kernel");
 
-    let root_dir = getenv_unwrap("CARGO_MANIFEST_DIR");
-
-    let root_path = Path::new(&root_dir);
-
-    let kernel_path = root_path.join("deps").join("seL4_kernel");
-
-    let fel4_manifest = PathBuf::from(getenv_unwrap("FEL4_MANIFEST_PATH"));
-
-    println!("cargo:rerun-if-changed={}", fel4_manifest.display());
-
-    // parse fel4.toml
-    let toml_config = get_toml_config(fel4_manifest, &getenv_unwrap("PROFILE"));
-
-    if cargo_target != toml_config.target {
-        panic!("Cargo is attempting to build for the {} target, however fel4.toml has declared the target to be {}", cargo_target, toml_config.target);
+    // println!("cargo:rerun-if-changed={}", fel4_manifest.display());  // TODO - move this to the calling location
+    let cargo_target = env::var("TARGET")
+        .map_err(|_| CmakeConfigurationError::MissingRequiredEnvVar("TARGET".to_string()))?;
+    if cargo_target != resolved_manifest.target.full_name() {
+        return Err(CmakeConfigurationError::CargoTargetToFel4TargetMismatch(
+            cargo_target,
+            resolved_manifest.target.full_name().to_string(),
+        ));
     }
 
     // CMAKE_TOOLCHAIN_FILE is resolved immediately by CMake
     cmake_config.define("CMAKE_TOOLCHAIN_FILE", kernel_path.join("gcc.cmake"));
-
     cmake_config.define("KERNEL_PATH", kernel_path);
 
-    // add options from build profile sub-table
-    add_cmake_options_from_table(
-        &toml_config.cmake_profile_config,
-        cmake_config,
-    );
-
-    // add options from target sub-table
-    add_cmake_options_from_table(
-        &toml_config.cmake_target_config,
-        cmake_config,
-    );
-
-    // add options from platform sub-table
-    add_cmake_options_from_table(
-        &toml_config.cmake_platform_config,
-        cmake_config,
-    );
+    add_cmake_definitions(cmake_config, &resolved_manifest.properties);
 
     // seL4 handles these so we clear them to prevent cmake-rs from
     // auto-populating
@@ -133,66 +345,28 @@ pub fn configure_cmake_build(cmake_config: &mut CmakeConfig) -> TomlConfig {
 
     // Ninja generator
     cmake_config.generator("Ninja");
-
-    toml_config
+    Ok(())
 }
 
-/// Add CMake configurations from a toml table.
-fn add_cmake_options_from_table(
-    toml_table: &toml::Value,
+fn add_cmake_definitions(
     cmake_config: &mut CmakeConfig,
+    properties: &HashMap<String, FlatTomlValue>,
 ) {
-    for (key, value) in toml_table.as_table().unwrap() {
-        // ignore other tables within this one
-        if value.is_table() {
-            continue;
-        }
-
-        add_cmake_definition(key, value, cmake_config);
+    for (name, value) in properties {
+        add_cmake_definition(cmake_config, name, value);
     }
 }
 
-/// Add a CMake configuration definition
-pub fn add_cmake_definition(
-    key: &String,
-    value: &toml::Value,
-    config: &mut CmakeConfig,
-) {
-    // booleans use the :<type> syntax, with ON/OFF values
-    // everything else is treated as a string
-    if value.type_str() == "boolean" {
-        if value.as_bool().unwrap() == true {
-            config.define(format!("{}:BOOL", key), "ON");
-        } else {
-            config.define(format!("{}:BOOL", key), "OFF");
+fn add_cmake_definition(config: &mut CmakeConfig, name: &String, value: &FlatTomlValue) {
+    match value {
+        FlatTomlValue::Boolean(b) => {
+            config.define(format!("{}:BOOL", name), if *b { "ON" } else { "OFF" })
         }
-    } else if value.type_str() == "integer" {
-        config.define(
-            key,
-            value
-                .as_integer()
-                .expect(&format!(
-                    "failed to convert key '{}' to integer",
-                    value
-                ))
-                .to_string(),
-        );
-    } else {
-        config.define(
-            key,
-            value
-                .as_str()
-                .expect(&format!("failed to convert key '{}' to str", value)),
-        );
-    }
-}
-
-/// Return an environment variable as a String.
-fn getenv_unwrap(v: &str) -> String {
-    match env::var(v) {
-        Ok(s) => s,
-        Err(..) => panic!("environment variable `{}` not defined", v),
-    }
+        FlatTomlValue::Integer(i) => config.define(name, i.to_string()),
+        FlatTomlValue::String(s) => config.define(name, s),
+        FlatTomlValue::Float(f) => config.define(name, f.to_string()),
+        FlatTomlValue::Datetime(d) => config.define(name, format!("{}", d)),
+    };
 }
 
 #[cfg(test)]
@@ -200,11 +374,12 @@ mod tests {
     use super::*;
 
     #[test]
-    #[should_panic]
-    fn getenv_unwrap_fails_loudly_on_missing_var() {
-        let key = "BLERM";
-        std::env::remove_var(key);
-        getenv_unwrap(key);
+    fn infer_manifest_location_from_env_happy_path() {
+        std::env::set_var("PROFILE", "debug");
+        std::env::set_var("FEL4_MANIFEST_PATH", "./somewhere/else");
+        let (p, b) = infer_manifest_location_from_env().expect("Oh no");
+        assert_eq!(PathBuf::from("./somewhere/else"), p);
+        assert_eq!(BuildProfile::Debug, b);
     }
 
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,181 @@
+use multimap::MultiMap;
+use std::collections::HashMap;
+use std::str::FromStr;
+use toml;
+
+/// The full content of a fel4 manifest
+pub struct FullFel4Manifest {
+    pub artifact_path: String,
+    pub target_specs_path: String,
+    pub selected_target: SupportedTarget,
+    pub selected_platform: SupportedPlatform,
+    pub targets: HashMap<SupportedTarget, FullFel4Target>,
+}
+
+/// The full content of a target within a fel4 manifest
+pub struct FullFel4Target {
+    pub identity: SupportedTarget,
+    pub direct_properties: Vec<FlatTomlProperty>,
+    pub build_profile_properties: MultiMap<BuildProfile, FlatTomlProperty>,
+    pub platform_properties: MultiMap<SupportedPlatform, FlatTomlProperty>,
+}
+
+/// Fel4 configuration for a particular target, platform, and build profile tuple
+/// resolved from a FullFel4Target
+pub struct Fel4Config {
+    pub artifact_path: String,
+    pub target_specs_path: String,
+    pub target: SupportedTarget,
+    pub platform: SupportedPlatform,
+    pub build_profile: BuildProfile,
+    pub properties: HashMap<String, FlatTomlValue>,
+}
+
+/// A single toml key-value pair where the value only includes non-nestable structures
+#[derive(PartialEq, Clone, Debug)]
+pub struct FlatTomlProperty {
+    pub name: String,
+    pub value: FlatTomlValue,
+}
+
+impl FlatTomlProperty {
+    pub fn new(name: String, value: FlatTomlValue) -> Self {
+        FlatTomlProperty { name, value }
+    }
+}
+
+/// A subset of `toml::Value` that only includes non-nestable structures
+#[derive(PartialEq, Clone, Debug)]
+pub enum FlatTomlValue {
+    /// Represents a TOML string
+    String(String),
+    /// Represents a TOML integer
+    Integer(i64),
+    /// Represents a TOML float
+    Float(f64),
+    /// Represents a TOML boolean
+    Boolean(bool),
+    /// Represents a TOML datetime,
+    Datetime(toml::value::Datetime),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum SupportedTarget {
+    X8664Sel4Fel4,
+    ArmSel4Fel4,
+}
+
+const TARGET_X86_64_SEL4_FEL4: &'static str = "x86_64-sel4-fel4";
+const TARGET_ARM_SEL4_FEL4: &'static str = "arm-sel4-fel4";
+
+impl SupportedTarget {
+    pub fn full_name(&self) -> &'static str {
+        match *self {
+            SupportedTarget::X8664Sel4Fel4 => TARGET_X86_64_SEL4_FEL4,
+            SupportedTarget::ArmSel4Fel4 => TARGET_ARM_SEL4_FEL4,
+        }
+    }
+
+    pub fn targets() -> Vec<SupportedTarget> {
+        vec![SupportedTarget::X8664Sel4Fel4, SupportedTarget::ArmSel4Fel4]
+    }
+
+    pub fn target_names() -> Vec<String> {
+        SupportedTarget::targets()
+            .iter()
+            .map(|t| t.full_name().into())
+            .collect()
+    }
+}
+
+impl FromStr for SupportedTarget {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+        match s {
+            TARGET_X86_64_SEL4_FEL4 => Ok(SupportedTarget::X8664Sel4Fel4),
+            TARGET_ARM_SEL4_FEL4 => Ok(SupportedTarget::ArmSel4Fel4),
+            _ => Err(s.to_string()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum SupportedPlatform {
+    PC99,
+    Sabre,
+}
+
+const PLATFORM_PC99: &'static str = "pc99";
+const PLATFORM_SABRE: &'static str = "sabre";
+
+impl SupportedPlatform {
+    pub fn full_name(&self) -> &'static str {
+        match *self {
+            SupportedPlatform::PC99 => PLATFORM_PC99,
+            SupportedPlatform::Sabre => PLATFORM_SABRE,
+        }
+    }
+
+    pub fn platforms() -> Vec<SupportedPlatform> {
+        vec![SupportedPlatform::PC99, SupportedPlatform::Sabre]
+    }
+
+    pub fn platform_names() -> Vec<String> {
+        SupportedPlatform::platforms()
+            .iter()
+            .map(|t| t.full_name().into())
+            .collect()
+    }
+}
+
+impl FromStr for SupportedPlatform {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+        match s {
+            PLATFORM_PC99 => Ok(SupportedPlatform::PC99),
+            PLATFORM_SABRE => Ok(SupportedPlatform::Sabre),
+            _ => Err(s.to_string()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum BuildProfile {
+    Debug,
+    Release,
+}
+const BUILD_PROFILE_DEBUG: &'static str = "debug";
+const BUILD_PROFILE_RELEASE: &'static str = "release";
+impl BuildProfile {
+    pub fn full_name(&self) -> &'static str {
+        match *self {
+            BuildProfile::Debug => BUILD_PROFILE_DEBUG,
+            BuildProfile::Release => BUILD_PROFILE_RELEASE,
+        }
+    }
+
+    pub fn build_profiles() -> Vec<BuildProfile> {
+        vec![BuildProfile::Debug, BuildProfile::Release]
+    }
+
+    pub fn build_profile_names() -> Vec<String> {
+        BuildProfile::build_profiles()
+            .iter()
+            .map(|t| t.full_name().into())
+            .collect()
+    }
+}
+
+impl FromStr for BuildProfile {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+        match s {
+            BUILD_PROFILE_DEBUG => Ok(BuildProfile::Debug),
+            BUILD_PROFILE_RELEASE => Ok(BuildProfile::Release),
+            _ => Err(s.to_string()),
+        }
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,11 +1,94 @@
 extern crate fel4_config;
 
-use std::path::PathBuf;
 use fel4_config::*;
+use std::path::PathBuf;
 
 #[test]
-fn parse_toml_config_happy_path() {
+fn get_full_manifest_happy_path() {
     let fel4_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_configs/fel4.toml");
-    let toml_config = get_toml_config(fel4_manifest, &"debug".to_string());
-    assert_eq!("x86_64-sel4-fel4", &toml_config.target)
+    let manifest =
+        get_full_manifest(fel4_manifest).expect("Should be able to read the default fel4.toml");
+    assert_eq!("artifacts", manifest.artifact_path);
+    assert_eq!("targets", manifest.target_specs_path);
+    assert_eq!(SupportedTarget::X8664Sel4Fel4, manifest.selected_target);
+    assert_eq!(SupportedPlatform::PC99, manifest.selected_platform);
+    assert_eq!(2, manifest.targets.len());
+    let x86_target = manifest
+        .targets
+        .get(&SupportedTarget::X8664Sel4Fel4)
+        .unwrap();
+    assert!(
+        x86_target
+            .direct_properties
+            .iter()
+            .any(|p| p.name == "BuildWithCommonSimulationSettings")
+    );
+    assert_eq!(
+        FlatTomlValue::String("x86".to_string()),
+        x86_target
+            .direct_properties
+            .iter()
+            .find(|p| p.name == "KernelArch")
+            .unwrap()
+            .value
+    );
+    assert_eq!(
+        FlatTomlValue::Boolean(true),
+        x86_target
+            .build_profile_properties
+            .get_vec(&BuildProfile::Debug)
+            .unwrap()
+            .iter()
+            .find(|p| p.name == "KernelDebugBuild")
+            .unwrap()
+            .value
+    );
+    assert_eq!(
+        FlatTomlValue::Boolean(false),
+        x86_target
+            .build_profile_properties
+            .get_vec(&BuildProfile::Release)
+            .unwrap()
+            .iter()
+            .find(|p| p.name == "KernelDebugBuild")
+            .unwrap()
+            .value
+    );
+    assert_eq!(
+        FlatTomlValue::String("nehalem".to_string()),
+        x86_target
+            .platform_properties
+            .get_vec(&SupportedPlatform::PC99)
+            .unwrap()
+            .iter()
+            .find(|p| p.name == "KernelX86MicroArch")
+            .unwrap()
+            .value
+    );
+    let arm_target = manifest.targets.get(&SupportedTarget::ArmSel4Fel4).unwrap();
+    assert_eq!(
+        FlatTomlValue::String("aarch32".to_string()),
+        arm_target
+            .direct_properties
+            .iter()
+            .find(|p| p.name == "KernelArmSel4Arch")
+            .unwrap()
+            .value
+    );
+}
+
+#[test]
+fn get_resolved_manifest_happy_path() {
+    let fel4_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_configs/fel4.toml");
+    let full =
+        get_full_manifest(fel4_manifest).expect("Should be able to read the default fel4.toml");
+    let manifest = resolve_fel4_config(full, &BuildProfile::Debug)
+        .expect("Should have been able to resolve all this");
+    assert_eq!(SupportedTarget::X8664Sel4Fel4, manifest.target);
+    assert_eq!(SupportedPlatform::PC99, manifest.platform);
+    assert_eq!(BuildProfile::Debug, manifest.build_profile);
+    assert_eq!(
+        &FlatTomlValue::String("x86".to_string()),
+        manifest.properties.get("KernelArch").unwrap()
+    );
 }


### PR DESCRIPTION
* Prefer the use of `Result` returns to panics
* Split up some of the giant functions into smaller bits
* Use a two-phase approach to config representation to allow future analysis of multiple targets/options rather than just the currently-selected target/platform/build tuple's properties.

CC: @pittma 